### PR TITLE
Added link to Arabic language Translation

### DIFF
--- a/index.md
+++ b/index.md
@@ -93,6 +93,7 @@ Some more URLs:
 - [Spanish](https://missing-semester-esp.github.io/)
 - [Turkish](https://missing-semester-tr.github.io/)
 - [Vietnamese](https://missing-semester-vn.github.io/)
+- [Arabic](https://missing-semester-ar.github.io/)
 
 Note: these are external links to community translations. We have not vetted
 them.


### PR DESCRIPTION
I started to work on the Arabic langauge translation of the website. currently I have index.md page and part of _2020/version-control.md

please added it so i can gain more support and collaboration to finish all the content. 

the repo for the Arabic language is:
https://github.com/missing-semester-ar/missing-semester-ar.github.io
